### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/packages/http/src/router/path-utils.ts
+++ b/packages/http/src/router/path-utils.ts
@@ -8,6 +8,7 @@ export interface RouteMatcher {
 export const createRouteMatcher = (path: string): RouteMatcher => {
   const paramNames: string[] = [];
   const pattern = path
+    .replace(/\\/g, '\\\\')
     .replace(/\//g, '\\/')
     .replace(paramPattern, (_, paramName: string) => {
       paramNames.push(paramName);


### PR DESCRIPTION
Potential fix for [https://github.com/Nael-Studio/nael-platform/security/code-scanning/3](https://github.com/Nael-Studio/nael-platform/security/code-scanning/3)

In general, to fix this problem, any metacharacters in `path` that have special meaning in regular expressions should be properly escaped before being interpolated into a `RegExp` constructor. This means backslashes (`\`) must be escaped as `\\`, as well as any other regex metacharacters if arbitrary input is possible.

However, considering the current code, the primary omission is just the lack of double-escaping for pre-existing backslashes before any other replacement is done. The best change, with minimal impact on the rest of the code, is to insert a `.replace(/\\/g, '\\\\')` step at the start of building the `pattern` at line 10, before any slashes or param replacements. This ensures that any backslashes appearing in the input are safely escaped for regex usage.

**Where to change:**
- File: `packages/http/src/router/path-utils.ts`
- Lines: add `.replace(/\\/g, '\\\\')` to the beginning of the `pattern` replacement chain at line 10.

**Additional requirements:**
- No additional imports or dependencies are needed, as this utilizes standard JS string and regex behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
