### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,5 +1,8 @@
 name: PR Build & Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Nael-Studio/nael-platform/security/code-scanning/2](https://github.com/Nael-Studio/nael-platform/security/code-scanning/2)

To fix this problem, add a top-level `permissions:` block to the workflow YAML file, right after the `name:` and before `jobs:`. This ensures that all jobs inherit these permission restrictions unless overridden. For the presented workflow, the minimal necessary permission is `contents: read`, as neither job performs any write actions or modifies repository contents/pull requests. Specifically, insert:

```yaml
permissions:
  contents: read
```

between the `name:` and `jobs:` sections.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
