### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,4 +1,6 @@
 name: PR Build & Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Nael-Studio/nael-platform/security/code-scanning/1](https://github.com/Nael-Studio/nael-platform/security/code-scanning/1)

To fix this problem, explicitly declare the least privilege required in a `permissions:` block to the workflow or job. The minimal required scope for most build and test jobs (that only need to check out code) is `contents: read`. This can be set at the workflow root so that all jobs inherit it automatically, unless a job needs broader permissions. Specifically, add the following block:

```yaml
permissions:
  contents: read
```

This should be inserted directly below the `name` field at the top of the file, before any `on:` or `env:` blocks. This will effectively restrict the `GITHUB_TOKEN` for the entire workflow to read-only access to repository contents, which is sufficient for checkouts by `actions/checkout` and no more.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
