### PR TITLE
fix: change trigger from release to push for versioned tags in publis…

### DIFF
--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -1,8 +1,9 @@
 name: publish-mcp-server
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates the workflow trigger for the `publish-mcp-server` GitHub Actions workflow. Instead of running on every published release, the workflow will now only run when a tag matching the semantic versioning pattern (e.g., `1.2.3`) is pushed.

Workflow trigger change:

* Changed the trigger in `.github/workflows/publish-mcp-server.yml` from running on release publication to running on pushes of tags that match the `[0-9]+.[0-9]+.[0-9]+` pattern, aligning workflow execution with semantic version tag pushes