### PR TITLE
fix: correct EOF delimiter syntax in publish workflow

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -48,9 +48,9 @@ jobs:
           fi
 
           {
-            echo "list<<'EOF'"
+            echo "list<<EOF"
             cat packages.txt
-            echo 'EOF'
+            echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
           echo "Discovered $(wc -l < packages.txt | tr -d ' ') publishable package(s)."


### PR DESCRIPTION
This pull request makes a minor fix to the GitHub Actions workflow for publishing npm packages. The change corrects the way multi-line output is written to the `GITHUB_OUTPUT` variable, ensuring proper syntax for the output block.

* Fixed the syntax for writing multi-line output to `GITHUB_OUTPUT` in `.github/workflows/publish-npm-packages.yml` by replacing single quotes with double quotes around the `EOF` marker.